### PR TITLE
Fix GestureDetector unfocus tap handler

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
         builder: (context, state) {
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
-            onTap: FocusManager.instance.primaryFocus?.unfocus,
+            onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
             child: MaterialApp.router(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Summary
- wrap `FocusManager.instance.primaryFocus?.unfocus()` in closure for GestureDetector

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e61dac47c8321b1306a5465be5c02